### PR TITLE
fix: breadcrumb logic

### DIFF
--- a/blocks/breadcrumb/breadcrumb.js
+++ b/blocks/breadcrumb/breadcrumb.js
@@ -1,8 +1,12 @@
 const getPageTitle = async (url) => {
   const resp = await fetch(url);
-  const html = document.createElement('div');
-  html.innerHTML = await resp.text();
-  return html.querySelector('title').innerText;
+  if (resp.ok) {
+    const html = document.createElement('div');
+    html.innerHTML = await resp.text();
+    return html.querySelector('title').innerText;
+  }
+
+  return '';
 };
 
 const getAllPathsExceptCurrent = async (paths) => {
@@ -16,7 +20,9 @@ const getAllPathsExceptCurrent = async (paths) => {
     const url = `${window.location.origin}${path}`;
     /* eslint-disable-next-line no-await-in-loop */
     const name = await getPageTitle(url);
-    result.push({ path, name, url });
+    if (name) {
+      result.push({ path, name, url });
+    }
   }
   return result;
 };

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -11,6 +11,7 @@ import {
   loadBlocks,
   loadCSS,
   decorateBlock,
+  getMetadata,
 } from './lib-franklin.js';
 
 const PRODUCTION_DOMAINS = ['www.elixirsolutions.com'];
@@ -80,9 +81,7 @@ function buildHeroBlock(main) {
  * @param {Element} main The container element
  */
 function buildBreadcrumbBlock(main) {
-  const title = document.querySelector('head title');
-
-  if (title.innerText !== 'Elixir-Home' && window.isErrorPage !== true) {
+  if (window.location.pathname !== '/' && window.isErrorPage !== true && !getMetadata('hideBreadcrumb')) {
     const section = document.createElement('div');
     section.append(buildBlock('breadcrumb', { elems: [] }));
     main.prepend(section);


### PR DESCRIPTION
2 minor fixes here:
1. if a parent path isn't found (404) don't include it in the breadcrumb. should never happen, but JIC
2. adjust logic for when breadcrumb is not added:

* is not the home page
* is not an error page
* doesn't have a metadata set of hideBreadcrumb (no where we use this yet, but nice to have if we ever need to hide the breadcrumb for certain pages)

Test URLs:
- Before: https://main--elixirsolutions--hlxsites.hlx.live/
- After: https://breadcrumb-fix--elixirsolutions--hlxsites.hlx.live/
